### PR TITLE
Remove unused function parameter

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -7,11 +7,11 @@ function Store() {
 	this.state = this.update(this.state, {});
 }
 
-Store.prototype.getState = function(action) {
+Store.prototype.getState = function() {
 	return this.state;
 };
 
-Store.prototype.getPrevState = function(action) {
+Store.prototype.getPrevState = function() {
 	return this.prevState;
 };
 


### PR DESCRIPTION
You don't need `action` in `getState()` and `getPrevState()`
